### PR TITLE
Updates for minor spelling issues

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -246,7 +246,7 @@
 							<li>outlier detection</li>
 							<li>health checking</li>
 							<li>traffic shaping</li>
-							<li>request shadowning</li>
+							<li>request shadowing</li>
 						</ul>
 					</section>
 
@@ -306,7 +306,7 @@
 							<li>L3/4 network filter</li>
 							<li>out of the box L7 filters</li>
 							<li>HTTP 2, including gRPC</li>
-							<li>baked in service discvoery/health checking</li>
+							<li>baked in service discovery/health checking</li>
 							<li>advanced load balancing</li>
 							<li>stats, metrics, tracing</li>
 							<li>dynamic configuration through xDS</li>


### PR DESCRIPTION
fixing a couple of minor spelling issues - the diagram on slide #62 also has an issue not fixed here - `ingres` instead of `ingress`