### PR TITLE
Make routing rules JSON readable

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -2234,15 +2234,56 @@
             In the response we should see an entry for:
 
             ```
-            {"name":"reviews.istio-samples.svc.cluster.local|http","domains":["reviews:9080","reviews","reviews
-            .istio-samples:9080","reviews.istio-samples","reviews.istio-samples.svc:9080","reviews.istio-samples.svc",
-            "reviews.istio-samples.svc.cluster:9080","reviews.istio-samples.svc.cluster","reviews.istio-samples.svc
-            .cluster.local:9080","reviews.istio-samples.svc.cluster.local","172.30.160.190:9080","172.30.160.190"],
-            "routes":[{"match":{"prefix":"/","headers":[{"name":"cookie","value":"^(.*?;)?(user=jason)(;.*)?$",
-            "regex":true}]},"route":{"cluster":"out.reviews.istio-samples.svc.cluster.local|http|version=v2",
-            "timeout":"0s"},"decorator":{"operation":"reviews-test-v2"}},{"match":
-            {"prefix":"/"},"route":{"cluster":"out.reviews.istio-samples.svc.cluster.local|http|version=v1",
-            "timeout":"0s"},"decorator":{"operation":"reviews-default"}}]}
+            {
+              "name": "reviews.istio-samples.svc.cluster.local|http",
+              "domains": [
+                "reviews:9080",
+                "reviews",
+                "reviews.istio-samples:9080",
+                "reviews.istio-samples",
+                "reviews.istio-samples.svc:9080",
+                "reviews.istio-samples.svc",
+                "reviews.istio-samples.svc.cluster:9080",
+                "reviews.istio-samples.svc.cluster",
+                "reviews.istio-samples.svc.cluster.local:9080",
+                "reviews.istio-samples.svc.cluster.local",
+                "172.30.160.190:9080",
+                "172.30.160.190"
+              ],
+              "routes": [
+                {
+                  "match": {
+                    "prefix": "/",
+                    "headers": [
+                      {
+                        "name": "cookie",
+                        "value": "^(.*?;)?(user=jason)(;.*)?$",
+                        "regex": true
+                      }
+                    ]
+                  },
+                  "route": {
+                    "cluster": "out.reviews.istio-samples.svc.cluster.local|http|version=v2",
+                    "timeout": "0s"
+                  },
+                  "decorator": {
+                    "operation": "reviews-test-v2"
+                  }
+                },
+                {
+                  "match": {
+                    "prefix": "/"
+                  },
+                  "route": {
+                    "cluster": "out.reviews.istio-samples.svc.cluster.local|http|version=v1",
+                    "timeout": "0s"
+                  },
+                  "decorator": {
+                    "operation": "reviews-default"
+                  }
+                }
+              ]
+            }
             ```
 
             Note the routing based on Cookie params.

--- a/slides/index.html
+++ b/slides/index.html
@@ -2242,7 +2242,7 @@
             "regex":true}]},"route":{"cluster":"out.reviews.istio-samples.svc.cluster.local|http|version=v2",
             "timeout":"0s"},"decorator":{"operation":"reviews-test-v2"}},{"match":
             {"prefix":"/"},"route":{"cluster":"out.reviews.istio-samples.svc.cluster.local|http|version=v1",
-            "timeout":"0s"},"decorator":{"operation":"reviews-default"}
+            "timeout":"0s"},"decorator":{"operation":"reviews-default"}}]}
             ```
 
             Note the routing based on Cookie params.


### PR DESCRIPTION
A simple change to pretty-print the JSON from in the "Where do routing rules live?" slide (currently 118). 

Unfortunately the `headers` doesn't render perfectly which is unfortunate. I assume this is a bug with reveal.js? Dropping indentation for that section to 1 (from 2) seemed to make it better but I left it as "clean" `jq .` output for now. 